### PR TITLE
refs #2205 マジックリンクのメール送信対応

### DIFF
--- a/.github/workflows/deploy-mail-api.yml
+++ b/.github/workflows/deploy-mail-api.yml
@@ -35,6 +35,14 @@ jobs:
         working-directory: mail-api
         run: pnpm install --frozen-lockfile
 
+      - name: Type check
+        working-directory: mail-api
+        run: pnpm type-check
+
+      - name: Run tests
+        working-directory: mail-api
+        run: pnpm test
+
       - name: Ensure Pages project exists
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/admin/src/env.ts
+++ b/admin/src/env.ts
@@ -11,4 +11,10 @@ export interface Env {
   DB?: D1Database;
   PAID_CONTENT?: R2Bucket;
   EVENTS_QUEUE?: Queue;
+  /** メールAPI URL（設定時は実メール送信、未設定時はコンソール出力） */
+  MAIL_API_URL?: string;
+  /** メールAPI認証キー */
+  MAIL_API_KEY?: string;
+  /** 許可されたコールバックURLのオリジン（カンマ区切り） */
+  ALLOWED_CALLBACK_ORIGINS?: string;
 }

--- a/admin/src/infrastructure/mail/mail-api-sender.ts
+++ b/admin/src/infrastructure/mail/mail-api-sender.ts
@@ -1,0 +1,51 @@
+import type { MailSender, MailSendRequest } from '../../application/auth/mail-sender.js'
+
+interface MailApiResponse {
+  success: boolean
+  messageId?: string
+  error?: string
+  message?: string
+}
+
+/**
+ * mail-api を使用してメールを送信する MailSender 実装
+ * 本番環境で使用
+ */
+export class MailApiSender implements MailSender {
+  constructor(
+    private readonly apiUrl: string,
+    private readonly apiKey: string
+  ) {}
+
+  async send(request: MailSendRequest): Promise<void> {
+    const response = await fetch(`${this.apiUrl}/send`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': this.apiKey,
+      },
+      body: JSON.stringify({
+        to: request.to,
+        subject: request.subject,
+        text: request.text,
+        html: request.html,
+      }),
+    })
+
+    if (!response.ok) {
+      let errorMessage = `HTTP ${response.status}: ${response.statusText}`
+      try {
+        const errorData = (await response.json()) as MailApiResponse
+        errorMessage = errorData.error || errorData.message || errorMessage
+      } catch {
+        // JSONパースエラーは無視
+      }
+      throw new Error(`Mail API error: ${errorMessage}`)
+    }
+
+    const data = (await response.json()) as MailApiResponse
+    if (!data.success) {
+      throw new Error(`Mail API error: ${data.error || 'Unknown error'}`)
+    }
+  }
+}

--- a/admin/src/presentation/http/handlers/auth-request-link.ts
+++ b/admin/src/presentation/http/handlers/auth-request-link.ts
@@ -1,8 +1,62 @@
 import type { Env } from '../../../env.js'
+import type { MailSender } from '../../../application/auth/mail-sender.js'
 import { requestMagicLink } from '../../../application/auth/request-magic-link.js'
 import { D1MagicLinkRepository } from '../../../infrastructure/db/d1-magic-link-repository.js'
 import { ConsoleMailSender } from '../../../infrastructure/mail/console-mail-sender.js'
+import { MailApiSender } from '../../../infrastructure/mail/mail-api-sender.js'
 import { hashToken, generateSecureToken, generateId } from '../../../infrastructure/crypto/hash.js'
+
+/**
+ * callbackUrl が許可されたオリジンかどうかを検証する
+ * @param callbackUrl 検証対象のURL
+ * @param env 環境変数
+ * @returns 許可されていれば true
+ */
+function validateCallbackUrl(callbackUrl: string, env: Env): boolean {
+  try {
+    const url = new URL(callbackUrl)
+
+    // 開発環境では localhost を許可
+    if (env.ENV === 'development' && (url.hostname === 'localhost' || url.hostname === '127.0.0.1')) {
+      return true
+    }
+
+    // 許可されたオリジンのリストを取得
+    const allowedOrigins = env.ALLOWED_CALLBACK_ORIGINS?.split(',').map((o) => o.trim()) || []
+
+    // オリジンが許可リストに含まれているか確認
+    if (allowedOrigins.includes(url.origin)) {
+      return true
+    }
+
+    // ワイルドカード対応（*.example.com など）
+    for (const allowed of allowedOrigins) {
+      if (allowed.startsWith('*.')) {
+        const domain = allowed.slice(2)
+        if (url.hostname.endsWith(domain) || url.hostname === domain.slice(1)) {
+          return true
+        }
+      }
+    }
+
+    return false
+  } catch {
+    // URL パースエラーの場合は無効
+    return false
+  }
+}
+
+/**
+ * 環境に応じた MailSender を作成する
+ * MAIL_API_URL と MAIL_API_KEY が設定されていれば MailApiSender を使用
+ * そうでなければ ConsoleMailSender を使用（開発環境用）
+ */
+function createMailSender(env: Env): MailSender {
+  if (env.MAIL_API_URL && env.MAIL_API_KEY) {
+    return new MailApiSender(env.MAIL_API_URL, env.MAIL_API_KEY)
+  }
+  return new ConsoleMailSender()
+}
 
 interface RequestLinkBody {
   email: string
@@ -39,6 +93,17 @@ export async function handleAuthRequestLink(
     )
   }
 
+  // callbackUrl が指定されている場合は検証
+  if (body.callbackUrl) {
+    // ALLOWED_CALLBACK_ORIGINS が設定されている場合のみ検証
+    if (env.ALLOWED_CALLBACK_ORIGINS && !validateCallbackUrl(body.callbackUrl, env)) {
+      return new Response(
+        JSON.stringify({ error: 'Invalid callback URL: origin not allowed' }),
+        { status: 400, headers: { 'content-type': 'application/json; charset=utf-8' } }
+      )
+    }
+  }
+
   // Determine base URL for magic link
   // callbackUrl が指定されていればそれを使用、なければAPIのURLを使用
   const url = new URL(request.url)
@@ -68,7 +133,7 @@ export async function handleAuthRequestLink(
       },
       {
         magicLinkRepo: new D1MagicLinkRepository(env.DB),
-        mailSender: new ConsoleMailSender(), // TODO: Use real mail sender in production
+        mailSender: createMailSender(env),
         generateId,
         generateToken: () => generateSecureToken(32),
         hashToken,

--- a/admin/tests/infrastructure/mail/mail-api-sender.test.ts
+++ b/admin/tests/infrastructure/mail/mail-api-sender.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MailApiSender } from '../../../src/infrastructure/mail/mail-api-sender.js'
+
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+describe('MailApiSender', () => {
+  const apiUrl = 'https://mail-api.example.com'
+  const apiKey = 'test-api-key'
+  let sender: MailApiSender
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    sender = new MailApiSender(apiUrl, apiKey)
+  })
+
+  describe('send', () => {
+    it('should send email with correct parameters', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: true, messageId: 'msg_12345' }),
+      })
+
+      await sender.send({
+        to: 'user@example.com',
+        subject: 'ログインリンク',
+        text: 'ログインリンクです',
+        html: '<p>ログインリンクです</p>',
+      })
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${apiUrl}/send`,
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-API-Key': apiKey,
+          },
+        })
+      )
+
+      // リクエストボディを確認
+      const callArgs = mockFetch.mock.calls[0]
+      const requestBody = JSON.parse(callArgs[1].body)
+      expect(requestBody).toEqual({
+        to: 'user@example.com',
+        subject: 'ログインリンク',
+        text: 'ログインリンクです',
+        html: '<p>ログインリンクです</p>',
+      })
+    })
+
+    it('should send email without html when not provided', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: true, messageId: 'msg_12345' }),
+      })
+
+      await sender.send({
+        to: 'user@example.com',
+        subject: 'ログインリンク',
+        text: 'ログインリンクです',
+      })
+
+      const callArgs = mockFetch.mock.calls[0]
+      const requestBody = JSON.parse(callArgs[1].body)
+      expect(requestBody.html).toBeUndefined()
+    })
+
+    it('should throw error on HTTP error response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: () => Promise.resolve({ error: 'Mail provider error' }),
+      })
+
+      await expect(
+        sender.send({
+          to: 'user@example.com',
+          subject: 'Test',
+          text: 'Test',
+        })
+      ).rejects.toThrow('Mail API error: Mail provider error')
+    })
+
+    it('should throw error when success is false in response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: false, error: 'Invalid recipient' }),
+      })
+
+      await expect(
+        sender.send({
+          to: 'user@example.com',
+          subject: 'Test',
+          text: 'Test',
+        })
+      ).rejects.toThrow('Mail API error: Invalid recipient')
+    })
+
+    it('should handle JSON parse error gracefully', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: () => Promise.reject(new Error('Invalid JSON')),
+      })
+
+      await expect(
+        sender.send({
+          to: 'user@example.com',
+          subject: 'Test',
+          text: 'Test',
+        })
+      ).rejects.toThrow('Mail API error: HTTP 500: Internal Server Error')
+    })
+
+    it('should handle network error', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'))
+
+      await expect(
+        sender.send({
+          to: 'user@example.com',
+          subject: 'Test',
+          text: 'Test',
+        })
+      ).rejects.toThrow('Network error')
+    })
+  })
+})

--- a/mail-api/package.json
+++ b/mail-api/package.json
@@ -7,6 +7,8 @@
     "dev": "wrangler pages dev dist",
     "build": "node build.mjs",
     "typecheck": "tsc --noEmit",
+    "type-check": "tsc --noEmit",
+    "test": "vitest run",
     "deploy": "pnpm build && wrangler pages deploy dist --project-name=techdoc-mail-api",
     "deploy:production": "pnpm build && wrangler pages deploy dist --project-name=techdoc-mail-api --branch=main"
   },
@@ -18,6 +20,7 @@
     "@cloudflare/workers-types": "^4.20241205.0",
     "esbuild": "^0.24.0",
     "typescript": "^5.9.2",
+    "vitest": "^1.6.0",
     "wrangler": "^4.0.0"
   }
 }

--- a/mail-api/src/index.ts
+++ b/mail-api/src/index.ts
@@ -8,10 +8,11 @@ import { cors } from 'hono/cors';
 import { z } from 'zod';
 import type { Env } from './types';
 import { createMailProvider } from './providers';
+import { apiKeyAuth } from './middleware/api-key-auth';
 
 const app = new Hono<{ Bindings: Env }>();
 
-// リクエストバリデーションスキーマ
+// リクエストバリデーションスキーマ（お問い合わせ用）
 const contactSchema = z.object({
   name: z
     .string()
@@ -30,6 +31,23 @@ const contactSchema = z.object({
     .min(1, 'お問い合わせ内容を入力してください')
     .max(5000, 'お問い合わせ内容は5000文字以内で入力してください'),
   siteName: z.string().optional(),
+});
+
+// リクエストバリデーションスキーマ（トランザクショナルメール用）
+const sendSchema = z.object({
+  to: z
+    .string()
+    .min(1, '送信先メールアドレスを入力してください')
+    .email('有効なメールアドレスを入力してください'),
+  subject: z
+    .string()
+    .min(1, '件名を入力してください')
+    .max(200, '件名は200文字以内で入力してください'),
+  text: z
+    .string()
+    .min(1, '本文を入力してください')
+    .max(10000, '本文は10000文字以内で入力してください'),
+  html: z.string().optional(),
 });
 
 // CORS設定
@@ -155,6 +173,87 @@ app.post('/contact', async (c) => {
       {
         success: false,
         message: 'サーバーエラーが発生しました。しばらく経ってから再度お試しください。',
+        debug: error instanceof Error ? error.message : 'Unknown error',
+      },
+      500
+    );
+  }
+});
+
+// トランザクショナルメール送信API（内部API、認証必須）
+app.post('/send', apiKeyAuth, async (c) => {
+  try {
+    const body = await c.req.json();
+
+    // バリデーション
+    const result = sendSchema.safeParse(body);
+    if (!result.success) {
+      const errors: Record<string, string[]> = {};
+      for (const error of result.error.errors) {
+        const path = error.path.join('.');
+        if (!errors[path]) {
+          errors[path] = [];
+        }
+        errors[path].push(error.message);
+      }
+      return c.json(
+        {
+          success: false,
+          message: '入力内容に誤りがあります',
+          errors,
+        },
+        400
+      );
+    }
+
+    const { to, subject, text, html } = result.data;
+
+    // メールプロバイダー作成
+    let mailProvider;
+    try {
+      mailProvider = createMailProvider(c.env);
+    } catch (providerError) {
+      console.error('Failed to create mail provider:', providerError);
+      return c.json(
+        {
+          success: false,
+          message: 'メール設定エラー',
+          debug: providerError instanceof Error ? providerError.message : 'Unknown provider error',
+        },
+        500
+      );
+    }
+
+    // トランザクショナルメール送信
+    const sendResult = await mailProvider.sendTransactional({
+      to,
+      subject,
+      text,
+      html,
+    });
+
+    if (!sendResult.success) {
+      console.error(`Transactional mail send failed (${mailProvider.name}):`, sendResult.error);
+      return c.json(
+        {
+          success: false,
+          message: 'メールの送信に失敗しました',
+          debug: sendResult.error,
+        },
+        500
+      );
+    }
+
+    return c.json({
+      success: true,
+      messageId: sendResult.messageId,
+    });
+  } catch (error) {
+    console.error('Send API error:', error);
+    return c.json(
+      {
+        success: false,
+        message: 'サーバーエラーが発生しました',
         debug: error instanceof Error ? error.message : 'Unknown error',
       },
       500

--- a/mail-api/src/middleware/api-key-auth.ts
+++ b/mail-api/src/middleware/api-key-auth.ts
@@ -1,0 +1,35 @@
+/**
+ * APIキー認証ミドルウェア
+ * 内部API（/send など）へのアクセスを制限するために使用
+ */
+
+import { createMiddleware } from 'hono/factory';
+import type { Env } from '../types';
+
+/**
+ * X-API-Key ヘッダーを検証するミドルウェア
+ * INTERNAL_API_KEY 環境変数と照合する
+ */
+export const apiKeyAuth = createMiddleware<{ Bindings: Env }>(async (c, next) => {
+  const apiKey = c.req.header('X-API-Key');
+  const expectedKey = c.env.INTERNAL_API_KEY;
+
+  // INTERNAL_API_KEY が設定されていない場合は認証をスキップ（開発環境用）
+  if (!expectedKey) {
+    console.warn('INTERNAL_API_KEY is not set, skipping API key authentication');
+    await next();
+    return;
+  }
+
+  if (!apiKey || apiKey !== expectedKey) {
+    return c.json(
+      {
+        success: false,
+        error: 'Unauthorized: Invalid or missing API key',
+      },
+      401
+    );
+  }
+
+  await next();
+});

--- a/mail-api/src/types.ts
+++ b/mail-api/src/types.ts
@@ -23,6 +23,18 @@ export interface SendMailResult {
   error?: string;
 }
 
+/** トランザクショナルメール送信パラメータ（任意宛先） */
+export interface TransactionalMailParams {
+  /** 送信先メールアドレス */
+  to: string;
+  /** 件名 */
+  subject: string;
+  /** プレーンテキスト本文 */
+  text: string;
+  /** HTML本文（オプション） */
+  html?: string;
+}
+
 /** メールプロバイダーインターフェース */
 export interface MailProvider {
   /** プロバイダー名 */
@@ -31,6 +43,8 @@ export interface MailProvider {
   send(params: SendMailParams): Promise<SendMailResult>;
   /** 問い合わせ者への自動返信メール送信 */
   sendAutoReply(params: SendMailParams): Promise<SendMailResult>;
+  /** トランザクショナルメール送信（任意宛先） */
+  sendTransactional(params: TransactionalMailParams): Promise<SendMailResult>;
 }
 
 /** サポートするプロバイダー種別 */
@@ -47,4 +61,6 @@ export interface Env {
   GMAIL_CLIENT_ID?: string;
   GMAIL_CLIENT_SECRET?: string;
   GMAIL_REFRESH_TOKEN?: string;
+  /** 内部API認証キー（/send エンドポイント用） */
+  INTERNAL_API_KEY?: string;
 }

--- a/mail-api/tests/send.test.ts
+++ b/mail-api/tests/send.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import app from '../src/index'
+import type { Env } from '../src/types'
+
+// Hono テスト用のモック環境
+const createMockEnv = (overrides?: Partial<Env>): Env => ({
+  MAIL_PROVIDER: 'resend',
+  MAIL_TO_EMAIL: 'admin@example.com',
+  MAIL_FROM_EMAIL: 'noreply@example.com',
+  ALLOWED_ORIGINS: 'https://example.com',
+  RESEND_API_KEY: 'test-resend-key',
+  INTERNAL_API_KEY: 'test-internal-key',
+  ...overrides,
+})
+
+// fetch をモック
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+describe('POST /send', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // デフォルトで成功レスポンスを返す
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: 'msg_12345' }),
+    })
+  })
+
+  it('should return 401 when API key is missing', async () => {
+    const env = createMockEnv()
+    const req = new Request('http://localhost/send', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        to: 'user@example.com',
+        subject: 'Test Subject',
+        text: 'Test body',
+      }),
+    })
+
+    const res = await app.fetch(req, env)
+
+    expect(res.status).toBe(401)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.error).toContain('Unauthorized')
+  })
+
+  it('should return 401 when API key is invalid', async () => {
+    const env = createMockEnv()
+    const req = new Request('http://localhost/send', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': 'wrong-key',
+      },
+      body: JSON.stringify({
+        to: 'user@example.com',
+        subject: 'Test Subject',
+        text: 'Test body',
+      }),
+    })
+
+    const res = await app.fetch(req, env)
+
+    expect(res.status).toBe(401)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+  })
+
+  it('should return 400 when required fields are missing', async () => {
+    const env = createMockEnv()
+    const req = new Request('http://localhost/send', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': 'test-internal-key',
+      },
+      body: JSON.stringify({
+        to: 'user@example.com',
+        // subject missing
+        text: 'Test body',
+      }),
+    })
+
+    const res = await app.fetch(req, env)
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.errors).toBeDefined()
+  })
+
+  it('should return 400 when email is invalid', async () => {
+    const env = createMockEnv()
+    const req = new Request('http://localhost/send', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': 'test-internal-key',
+      },
+      body: JSON.stringify({
+        to: 'invalid-email',
+        subject: 'Test Subject',
+        text: 'Test body',
+      }),
+    })
+
+    const res = await app.fetch(req, env)
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.errors?.to).toBeDefined()
+  })
+
+  it('should successfully send email with valid request', async () => {
+    const env = createMockEnv()
+    const req = new Request('http://localhost/send', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': 'test-internal-key',
+      },
+      body: JSON.stringify({
+        to: 'user@example.com',
+        subject: 'Test Subject',
+        text: 'Test body',
+      }),
+    })
+
+    const res = await app.fetch(req, env)
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.messageId).toBe('msg_12345')
+
+    // Resend API が呼ばれたことを確認
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.resend.com/emails',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Authorization': 'Bearer test-resend-key',
+        }),
+      })
+    )
+  })
+
+  it('should include html in request when provided', async () => {
+    const env = createMockEnv()
+    const req = new Request('http://localhost/send', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': 'test-internal-key',
+      },
+      body: JSON.stringify({
+        to: 'user@example.com',
+        subject: 'Test Subject',
+        text: 'Test body',
+        html: '<p>Test HTML body</p>',
+      }),
+    })
+
+    const res = await app.fetch(req, env)
+
+    expect(res.status).toBe(200)
+
+    // リクエストボディに html が含まれていることを確認
+    const callArgs = mockFetch.mock.calls[0]
+    const requestBody = JSON.parse(callArgs[1].body)
+    expect(requestBody.html).toBe('<p>Test HTML body</p>')
+  })
+
+  it('should skip API key auth when INTERNAL_API_KEY is not set', async () => {
+    const env = createMockEnv({ INTERNAL_API_KEY: undefined })
+    const req = new Request('http://localhost/send', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        // API key not provided
+      },
+      body: JSON.stringify({
+        to: 'user@example.com',
+        subject: 'Test Subject',
+        text: 'Test body',
+      }),
+    })
+
+    const res = await app.fetch(req, env)
+
+    // 認証がスキップされ、メール送信が成功する
+    expect(res.status).toBe(200)
+  })
+
+  it('should return 500 when mail provider fails', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: () => Promise.resolve({ message: 'Provider error' }),
+    })
+
+    const env = createMockEnv()
+    const req = new Request('http://localhost/send', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': 'test-internal-key',
+      },
+      body: JSON.stringify({
+        to: 'user@example.com',
+        subject: 'Test Subject',
+        text: 'Test body',
+      }),
+    })
+
+    const res = await app.fetch(req, env)
+
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+  })
+})
+
+describe('POST /contact', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: 'msg_12345' }),
+    })
+  })
+
+  it('should not require API key for contact endpoint', async () => {
+    const env = createMockEnv()
+    const req = new Request('http://localhost/contact', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Origin': 'https://example.com',
+      },
+      body: JSON.stringify({
+        name: 'Test User',
+        email: 'user@example.com',
+        subject: 'Test Subject',
+        body: 'Test body content',
+      }),
+    })
+
+    const res = await app.fetch(req, env)
+
+    // APIキーなしでも成功する
+    expect(res.status).toBe(200)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@24.10.2)(lightningcss@1.30.2)
       wrangler:
         specifier: ^4.0.0
         version: 4.60.0(@cloudflare/workers-types@4.20260127.0)


### PR DESCRIPTION
## Summary
- mail-api にトランザクショナルメール送信機能（`POST /send`）を追加
- admin Worker に `MailApiSender` を実装し、環境変数で切り替え可能に
- callbackUrl の allowlist 検証によるセキュリティ対策を追加

## Test plan
- [ ] mail-api の型チェック・テストがパスすること
- [ ] admin Worker の型チェック・テストがパスすること
- [ ] https://dx-media.pages.dev でログインを試し、メールが届くこと
- [ ] メール内のリンクをクリックしてログインできること

🤖 Generated with [Claude Code](https://claude.com/claude-code)